### PR TITLE
Update the graze/guzzle-jsonrpc dependency to require version "^2.1"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require" : {
         "php" : ">=5.4.0",
-        "graze/guzzle-jsonrpc": ">=2.1"
+        "graze/guzzle-jsonrpc": "^2.1"
     },
     "autoload" : {
         "psr-4" : {


### PR DESCRIPTION
Version 3.0 of the dependency was released which includes breaking changes, this change ensures only the guzzle 5 version of the dependency is installed.
